### PR TITLE
fix MKL compilation

### DIFF
--- a/src/interface/monoid.cxx
+++ b/src/interface/monoid.cxx
@@ -1,6 +1,7 @@
 #include "../sparse_formats/csr.h"
 #include "set.h"
 #include "../shared/blas_symbs.h"
+#include "../shared/mkl_symbs.h"
 #include "../shared/util.h"
 using namespace CTF_int;
 namespace CTF {

--- a/src/interface/set.cxx
+++ b/src/interface/set.cxx
@@ -1,5 +1,6 @@
 #include "set.h"
 #include "../shared/blas_symbs.h"
+#include "../shared/mkl_symbs.h"
 #include "../shared/util.h"
 
 

--- a/src/shared/mkl_symbs.h
+++ b/src/shared/mkl_symbs.h
@@ -227,3 +227,5 @@ namespace CTF_BLAS {
   void MKL_ZCSRADD(char const * transa, int const * job, int const * sort, int const * n, int const * k, std::complex<double> const * a, int const * ja, int const * ia, std::complex<double> const * beta, std::complex<double> const * b, int const * jb, int const * ib, std::complex<double> * c, int * jc, int * ic, int const * nnzmax, int const * ierr);
 
 }
+
+#endif


### PR DESCRIPTION
It seems that these minor modifications are necessary to compile with MKL. Do the ```mkl_symbs.h``` include statements have to be surrounded by some ```#ifdef``` for compilation without MKL do go through smoothly?