### PR TITLE
Fix read_dense_from_file to have proper MPI access mode

### DIFF
--- a/src/tensor/untyped_tensor.cxx
+++ b/src/tensor/untyped_tensor.cxx
@@ -3215,7 +3215,7 @@ namespace CTF_int {
 
   void tensor::read_dense_from_file(char const * filename){
     MPI_File file;
-    MPI_File_open(this->wrld->comm, filename,  MPI_MODE_WRONLY | MPI_MODE_CREATE, MPI_INFO_NULL, &file);
+    MPI_File_open(this->wrld->comm, filename,  MPI_MODE_RDONLY, MPI_INFO_NULL, &file);
     this->read_dense_from_file(file, 0);
     MPI_File_close(&file);
 


### PR DESCRIPTION
`A.read_dense_from_file("filename.bin");` won't actually work as the access mode was set to write only.