### PR TITLE
Slicing: compare number of processors correctly

### DIFF
--- a/src/tensor/untyped_tensor.cxx
+++ b/src/tensor/untyped_tensor.cxx
@@ -985,7 +985,7 @@ namespace CTF_int {
     }
    // bool tsr_A_has_sym = false;
 
-    if (tsr_B->wrld->np <= tsr_A->wrld->np && !tsr_A->is_sparse){
+    if (tsr_B->wrld->np < tsr_A->wrld->np && !tsr_A->is_sparse){
       //usually 'read' elements of B from A, since B may be smalelr than A
       if (tsr_B->order == 0 || tsr_B->has_zero_edge_len){
         blk_sz_B = 0;


### PR DESCRIPTION
Hello,

we updated our version of `CTF` and were having some issues with regard
to the performance of the slicing in our code.

After some sniffing around we found this line in the slice method.
In version `1.4.1` the `if` statement had the `<` operator in it.
Some time after that this was changed into `<=` which according to my
understanding renders the `else` codeblock useless, i.e.
```cpp
...
} else {
      tsr_A->read_local_nnz(&sz_A, &all_data_A);
//      printf("sz_A+%ld\n",sz_A);
}
...
```

This means that when the number of processors where `tsr_B` is
distributed among is equal to `tsr_A`, there is also a checking of the
dimensions and padding for `A`, and this means that `CTF` has to read
  the data from `A`,
```cpp
...
      tsr_A->write(blk_sz_B, sr->mulid(), sr->addid(), blk_data_B, 'r');
...
```
which makes this block slower.

If this is true, this pull request would be a fix to the problem. We have
certainly tested it and it confirmed our suspicion. For slices of big tensors
the difference between the `<` and the `<=` version is up to `50%` in time,
according to our benchmarks. However, for small tensors it appears to be
roughly equivalent, which makes sense.

Thank you very much for your great project!
