### PR TITLE
Minimal changes for critter profiling

### DIFF
--- a/src/contraction/contraction.cxx
+++ b/src/contraction/contraction.cxx
@@ -2865,7 +2865,7 @@ namespace CTF_int {
     if (global_comm.rank == 0)
       printf("nnz_frac_A is %E, nnz_frac_B is %E, estimated nnz_frac_C is %E\n",nnz_frac_A,nnz_frac_B,nnz_frac_C);
   #endif
-    TAU_FSTOP(init_select_ctr_map);
+//    TAU_FSTOP(init_select_ctr_map);
     for (int i=0; i<(int)wrld->topovec.size(); i++){
 //      int tnum_choices = pow(num_choices,(int) wrld->topovec[i]->order);
       int tnum_choices = get_num_map_variants(wrld->topovec[i]);
@@ -2987,7 +2987,7 @@ namespace CTF_int {
     World * wrld = A->wrld;
     CommData global_comm = wrld->cdt;
    
-    TAU_FSTART(init_select_ctr_map);
+//    TAU_FSTART(init_select_ctr_map);
   #if BEST_VOL
     CTF_int::alloc_ptr(sizeof(int64_t)*A->order, (void**)&virt_blk_len_A);
     CTF_int::alloc_ptr(sizeof(int64_t)*B->order, (void**)&virt_blk_len_B);

--- a/src/contraction/contraction.cxx
+++ b/src/contraction/contraction.cxx
@@ -2883,7 +2883,7 @@ namespace CTF_int {
     int64_t valid_mappings = 0;
     int64_t choice_offset = 0;
     int64_t max_memuse = proc_bytes_available();
-    double nnz_frac_A, nnz_frac_B, nnz_frac_C;
+    //double nnz_frac_A, nnz_frac_B, nnz_frac_C;
     this->calc_nnz_frac(nnz_frac_A, nnz_frac_B, nnz_frac_C);
   #if VERBOSE >= 1
     if (global_comm.rank == 0)

--- a/src/contraction/contraction.cxx
+++ b/src/contraction/contraction.cxx
@@ -2883,12 +2883,6 @@ namespace CTF_int {
     int64_t valid_mappings = 0;
     int64_t choice_offset = 0;
     int64_t max_memuse = proc_bytes_available();
-    //double nnz_frac_A, nnz_frac_B, nnz_frac_C;
-    this->calc_nnz_frac(nnz_frac_A, nnz_frac_B, nnz_frac_C);
-  #if VERBOSE >= 1
-    if (global_comm.rank == 0)
-      printf("nnz_frac_A is %E, nnz_frac_B is %E, estimated nnz_frac_C is %E\n",nnz_frac_A,nnz_frac_B,nnz_frac_C);
-  #endif
 //    TAU_FSTOP(init_select_ctr_map);
     for (int i=0; i<(int)wrld->topovec.size(); i++){
 //      int tnum_choices = pow(num_choices,(int) wrld->topovec[i]->order);

--- a/src/shared/fompi_wrapper.h
+++ b/src/shared/fompi_wrapper.h
@@ -11,7 +11,11 @@ typedef foMPI_Win CTF_Win;
 #define MPI_Win_free(...) foMPI_Win_free(__VA_ARGS__)
 #define MPI_Put(...) foMPI_Put(__VA_ARGS__)
 #else
+#ifdef CRITTER
+#include "critter.h"
+#else
 #include <mpi.h>
+#endif
 typedef MPI_Win CTF_Win;
 #endif
 

--- a/src/shared/model.h
+++ b/src/shared/model.h
@@ -1,7 +1,11 @@
 #ifndef __MODEL_H__
 #define __MODEL_H__
 
+#ifdef CRITTER
+#include "critter.h"
+#else
 #include <mpi.h>
+#endif
 #include "init_models.h"
 
 #include <fstream>

--- a/src/shared/pmpi.h
+++ b/src/shared/pmpi.h
@@ -1,7 +1,11 @@
 #ifndef __PMPI_H__
 #define __PMPI_H__
 
+#ifdef CRITTER
+#include "critter.h"
+#else
 #include <mpi.h>
+#endif
 #include "../interface/timer.h"
 namespace CTF {
   void set_context(MPI_Comm);

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -277,8 +277,10 @@ namespace CTF_int {
   #define TAU_PROFILE_START(ARG)
   #define TAU_PROFILE_SET_NODE(ARG)
   #define TAU_PROFILE_SET_CONTEXT(ARG)
+  #ifndef CRITTER
   #define TAU_FSTART(ARG)
   #define TAU_FSTOP(ARG)
+  #endif
   #endif
   #define TIME(STRING) TAU_PROFILE(STRING, " ", TAU_DEFAULT)
 

--- a/src/tensor/untyped_tensor.cxx
+++ b/src/tensor/untyped_tensor.cxx
@@ -998,6 +998,7 @@ namespace CTF_int {
       int nvirt_B = tsr_B->calc_nvirt();
       if (tsr_B->wrld->np == tsr_A->wrld->np && !tsr_has_sym && !this->is_sparse && !A->is_sparse && nvirt_A == 1 && nvirt_B == 1 && !tsr_has_virt){
         push_slice(this, offsets_B, ends_B, beta, A, offsets_A, ends_A, alpha);
+        TAU_FSTOP(slice);
         return;
       }
     }


### PR DESCRIPTION
I incorporated minimal changes to get CTF to build with critter. The user can profile CTF code using critter by specifying the correct configure command.

I successfully built CTF using 3 configure commands on Stampede2:
1) CTF + Critter - `./configure '--no-dynamic' 'LIB_PATH=-L/home1/05608/tg849075/critter/lib -L/opt/intel/compilers_and_libraries_2018.2.199/linux/mkl/lib/intel64/' 'LIBS=-lcritter -lmkl_scalapack_lp64 -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -Wl,--end-group -lpthread -lm' 'CXXFLAGS=-O3 -DCRITTER' 'INCLUDES=-I/home1/05608/tg849075/critter/src/'`
2) CTF with no profiling - `./configure '--no-dynamic' 'LIB_PATH=-L/home1/05608/tg849075/critter/lib -L/opt/intel/compilers_and_libraries_2018.2.199/linux/mkl/lib/intel64/' 'LIBS=-lcritter -lmkl_scalapack_lp64 -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -Wl,--end-group -lpthread -lm' 'CXXFLAGS=-O3' 'INCLUDES=-I/home1/05608/tg849075/critter/src/'`
3) CTF + TAU/PMPI`./configure '--no-dynamic' 'LIB_PATH=-L/home1/05608/tg849075/critter/lib -L/opt/intel/compilers_and_libraries_2018.2.199/linux/mkl/lib/intel64/' 'LIBS=-lcritter -lmkl_scalapack_lp64 -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -Wl,--end-group -lpthread -lm' 'CXXFLAGS=-O3 -DPROFILE -DPMPI' 'INCLUDES=-I/home1/05608/tg849075/critter/src/'`

One might also consider adding a check in the configure file to prevent user from specifying both PROFILE and CRITTER, and PMPI and CRITTER. Also, although critter is an external library, I opted against creating its own `--with-critter` tag in the configure script to avoid messing with the code in the configure file. I think its simplest to just built critter on one's own, and have the 3 profiling tags {PMPI, PROFILE, CRITTER} be specifiable in the exact same way.