### PR TITLE
Removed barriers that can confuse critical path profilers

### DIFF
--- a/configure
+++ b/configure
@@ -1362,7 +1362,7 @@ for mod in mods:
             mod[0],
             [mod[1]],
             language="c++",
-            include_dirs=[numpy.get_include(),"$BUILDDIR/include","$INCLUDES".replace("-I",""),"."],
+            include_dirs=[numpy.get_include(),"$BUILDDIR/include","."]+"$INCLUDES".replace("-I","").split(),
             libraries="-lctf $LD_LIBS".replace('-l','').replace('$BDYNAMIC','').split(),
             extra_compile_args="$CXXFLAGS $CORRFLAGS".split(),
             extra_link_args="-L$BUILDDIR/lib_shared $CXXFLAGS $LD_LIB_PATH $LINKFLAGS $LDFLAGS".split()

--- a/configure
+++ b/configure
@@ -1362,7 +1362,7 @@ for mod in mods:
             mod[0],
             [mod[1]],
             language="c++",
-            include_dirs=[numpy.get_include(),"$BUILDDIR/include","."],
+            include_dirs=[numpy.get_include(),"$BUILDDIR/include","$INCLUDES".replace("-I",""),"."],
             libraries="-lctf $LD_LIBS".replace('-l','').replace('$BDYNAMIC','').split(),
             extra_compile_args="$CXXFLAGS $CORRFLAGS".split(),
             extra_link_args="-L$BUILDDIR/lib_shared $CXXFLAGS $LD_LIB_PATH $LINKFLAGS $LDFLAGS".split()

--- a/src/contraction/contraction.cxx
+++ b/src/contraction/contraction.cxx
@@ -4312,12 +4312,6 @@ namespace CTF_int {
   #endif
     }*/
 
-  #ifdef PROFILE
-    TAU_FSTART(pre_map_barrier);
-    MPI_Barrier(global_comm.cm);
-    TAU_FSTOP(pre_map_barrier);
-  #endif
-
   #ifdef PROFILE_MEMORY
     start_memprof(C->wrld->rank);
   #endif
@@ -4369,11 +4363,6 @@ namespace CTF_int {
     }
 #endif
 
-  #ifdef PROFILE
-    TAU_FSTART(pre_fold_barrier);
-    MPI_Barrier(global_comm.cm);
-    TAU_FSTOP(pre_fold_barrier);
-  #endif
   #endif
 
     //ASSERT(check_mapping());
@@ -4417,11 +4406,6 @@ namespace CTF_int {
   #endif
   //  stat = zero_out_padding(type->tid_A);
   //  stat = zero_out_padding(type->tid_B);
-  #ifdef PROFILE
-    TAU_FSTART(pre_ctr_func_barrier);
-    MPI_Barrier(global_comm.cm);
-    TAU_FSTOP(pre_ctr_func_barrier);
-  #endif
     TAU_FSTART(ctr_func);
     /* Invoke the contraction algorithm */
     A->topo->activate();
@@ -4510,11 +4494,6 @@ namespace CTF_int {
 
     A->topo->deactivate();
 
-  #ifdef PROFILE
-    TAU_FSTART(post_ctr_func_barrier);
-    MPI_Barrier(global_comm.cm);
-    TAU_FSTOP(post_ctr_func_barrier);
-  #endif
     TAU_FSTOP(ctr_func);
     A->unfold();
     B->unfold();

--- a/src/interface/common.h
+++ b/src/interface/common.h
@@ -15,7 +15,6 @@
 #include <limits.h>
 #include <random>
 
-#include <mpi.h>
 #include "../shared/model.h"
 
 /**

--- a/src/redistribution/dgtog_redist_ror.h
+++ b/src/redistribution/dgtog_redist_ror.h
@@ -702,9 +702,6 @@ void dgtog_reshuffle(int const *          sym,
   foMPI_Win_flush_all(win);
   foMPI_Win_free(&win);
 #else
-  TAU_FSTART(barrier_after_dgtog_reshuffle);
-  MPI_Barrier(ord_glb_comm.cm);
-  TAU_FSTOP(barrier_after_dgtog_reshuffle);
 #endif
   sr->dealloc(tsr_data);
 #endif

--- a/src/redistribution/redist.cxx
+++ b/src/redistribution/redist.cxx
@@ -481,7 +481,6 @@ namespace CTF_int {
 
     TAU_FSTART(block_reshuffle);
 #ifdef TUNE
-    MPI_Barrier(glb_comm.cm);
     double st_time = MPI_Wtime();
 #endif
 

--- a/src/summation/summation.cxx
+++ b/src/summation/summation.cxx
@@ -1660,11 +1660,6 @@ namespace CTF_int {
       tnsr_B->print_map();
   #endif
       /* Invoke the contraction algorithm */
-#ifdef PROFILE
-      TAU_FSTART(pre_sum_func_barrier);
-      MPI_Barrier(tnsr_B->wrld->comm);
-      TAU_FSTOP(pre_sum_func_barrier);
-#endif
       TAU_FSTART(activate_topo);
       tnsr_A->topo->activate();
       TAU_FSTOP(activate_topo);
@@ -1691,11 +1686,6 @@ namespace CTF_int {
         printf("\n");
       }
       }*/
-#ifdef PROFILE
-      TAU_FSTART(post_sum_func_barrier);
-      MPI_Barrier(tnsr_B->wrld->comm);
-      TAU_FSTOP(post_sum_func_barrier);
-#endif
       TAU_FSTART(sum_postprocessing);
       tnsr_A->topo->deactivate();
       tnsr_A->unfold();


### PR DESCRIPTION
I actually do not think these were confusing critter, because critter uses the -DCRITTER flag instead of the -DPROFILE flag. All of the barriers removed in this commit existed only if compiled with -DPROFILE.

Either way, since the barriers are used only when profiling and not for production, I don't see a negative to removing them (even if their presence somehow reports better performance for these per-process measurement profiling tests).