### PR TITLE
Removed extra mpi.h inclusion

### DIFF
--- a/src/interface/common.h
+++ b/src/interface/common.h
@@ -15,7 +15,6 @@
 #include <limits.h>
 #include <random>
 
-#include <mpi.h>
 #include "../shared/model.h"
 
 /**


### PR DESCRIPTION
CTF builds with/without specifying -DCRITTER.