### PR TITLE
Fix configure script for OSes without /bin/bash

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #configure script adapted from Aquarius software (https://github.cxxom/devinamatthews/aquarius)
 
 


### PR DESCRIPTION
Some operating systems do not have a copy or link to the bash shell
in `/bin/bash` (e.g. nixos). In general it is better to run
a script using `/usr/bin/env` to find the program.
