### PR TITLE
make comparison function for sets of tensor pointers const

### DIFF
--- a/src/interface/term.cxx
+++ b/src/interface/term.cxx
@@ -1096,7 +1096,7 @@ namespace CTF_int {
 
 
 namespace CTF_int {
-  bool tensor_name_less::operator()(CTF::Idx_Tensor* A, CTF::Idx_Tensor* B) {
+  bool tensor_name_less::operator()(CTF::Idx_Tensor* A, CTF::Idx_Tensor* B) const {
     if (A == NULL && B != NULL) {
       return true;
     } else if (A == NULL || B == NULL) {

--- a/src/interface/term.h
+++ b/src/interface/term.h
@@ -23,7 +23,7 @@ namespace CTF_int {
    * This ensures the set iteration order is consistent across nodes
    */
   struct tensor_name_less {
-    bool operator()(CTF::Idx_Tensor* A, CTF::Idx_Tensor* B);
+    bool operator()(CTF::Idx_Tensor* A, CTF::Idx_Tensor* B) const;
   };
 
 


### PR DESCRIPTION
Some versions of the compiler flag this as error:
`error: static assertion failed: comparison object must be invocable as const` #131 