### PR TITLE
Use named MPI datatypes for C++ datatypes

### DIFF
--- a/src/interface/common.cxx
+++ b/src/interface/common.cxx
@@ -4,10 +4,6 @@
 #include "../shared/util.h"
 #include <random>
 
-#ifdef USE_MPI_CPP
-#define MPI_CXX_DOUBLE_COMPLEX MPI::DOUBLE_COMPLEX
-#endif
-
 
 namespace CTF_int {
   int64_t computed_flop_count = 0;

--- a/src/interface/set.cxx
+++ b/src/interface/set.cxx
@@ -6,15 +6,9 @@
 
 namespace CTF_int {
 
-#ifdef USE_MPI_CPP
-  MPI_Datatype MPI_CTF_BOOL = MPI::BOOL;
-  MPI_Datatype MPI_CTF_DOUBLE_COMPLEX = MPI::DOUBLE_COMPLEX;
-  MPI_Datatype MPI_CTF_LONG_DOUBLE_COMPLEX = MPI::LONG_DOUBLE_COMPLEX;
-#else
   MPI_Datatype MPI_CTF_BOOL = MPI_CXX_BOOL;
   MPI_Datatype MPI_CTF_DOUBLE_COMPLEX = MPI_CXX_DOUBLE_COMPLEX;
   MPI_Datatype MPI_CTF_LONG_DOUBLE_COMPLEX = MPI_CXX_LONG_DOUBLE_COMPLEX;
-#endif
 
 #if USE_MKL
   void def_coo_to_csr_fl(int64_t nz, int nrow, float * csr_vs, int * csr_ja, int * csr_ia, float * coo_vs, int * coo_rs, int * coo_cs, bool to_csr){


### PR DESCRIPTION
MPI datatypes using the namespace syntax (MPI::BOOL etc.) were deprecated in MPI-3.0 and replaced with corresponding named MPI datatypes.

Building ATRIP (https://github.com/alejandrogallo/atrip) with MPICH (8.1.23) had issues with MPI_DATATYPE_NULL ending up being used for double complex numbers. Changing to named MPI datatypes fixed the issue.