### PR TITLE
fixed integer overflow in operator[] of (Const)PairIterator

### DIFF
--- a/src/tensor/algstrct.cxx
+++ b/src/tensor/algstrct.cxx
@@ -891,7 +891,7 @@ namespace CTF_int {
     sr=sr_; ptr=ptr_;
   }
 
-  ConstPairIterator ConstPairIterator::operator[](int n) const { 
+  ConstPairIterator ConstPairIterator::operator[](int64_t n) const { 
     return ConstPairIterator(sr,ptr+sr->pair_size()*n);
   }
 
@@ -916,7 +916,7 @@ namespace CTF_int {
     ptr=ptr_;
   }
 
-  PairIterator PairIterator::operator[](int n) const { 
+  PairIterator PairIterator::operator[](int64_t n) const { 
     return PairIterator(sr,ptr+sr->pair_size()*n);
   }
 

--- a/src/tensor/algstrct.h
+++ b/src/tensor/algstrct.h
@@ -462,7 +462,7 @@ namespace CTF_int {
       ConstPairIterator(algstrct const * sr_, char const * ptr_);
 
       /** \brief indexing moves by \param[in] n pairs */
-      ConstPairIterator operator[](int n) const;
+      ConstPairIterator operator[](int64_t n) const;
 
       /** \brief returns key of pair at head of ptr */
       int64_t k() const;
@@ -513,7 +513,7 @@ namespace CTF_int {
       PairIterator(algstrct const * sr_, char * ptr_);
 
       /** \brief indexing moves by \param[in] n pairs */
-      PairIterator operator[](int n) const;
+      PairIterator operator[](int64_t n) const;
 
       /** \brief returns key of pair at head of ptr */
       int64_t k() const;


### PR DESCRIPTION
Hello!

Thanks for this great project.

I observed an integer overflow in `PairIterator::operator[]` and `ConstPairIterator::operator[]`.

The following minimal example allows to reproduce this issue. I spotted it when filling a sparse tensor, but it could also occur in other situations.

```c++
int64_t N = 400; // works for (e.g.) N=100, crashes for N=400
int64_t dddd[] = {N, N, N, N}; // for tensor of order 4
int syms[] = {NS, NS, NS, NS}; // no symmetry
CTF::Tensor<double> T(4, true, dddd, syms, dw);

double sparsity = 0.1;
T.fill_sp_random(0, 1, sparsity); // crashes due to integer overflow
```

For this particular example the integer overflow is located here:
In the line 1039 of the source file `src/redistribution/sparse_rw.cxx` the variable `nwrite` is of type `int64_t` and can cause an integer overflow when it is passed to the `PairIterator::operator[]` in `swap_data[nwrite]`:
```c++
int64_t new_num_pair, nwrite, swp;
// [...]
int64_t ky = swap_data[nwrite].k();
```

The issue is fixed by replacing `operator[](int n)` with `operator[](int64_t n)`.
