### PR TITLE
recursive_expand_includes.sh messes up on omp.h and critter_*.h

### DIFF
--- a/src/scripts/recursive_expand_includes.sh
+++ b/src/scripts/recursive_expand_includes.sh
@@ -10,6 +10,12 @@ FULLFNAME="${FDIR}/${FNAME}"
 if grep -Fxq "$FULLFNAME" $SCRIPT_DIR/visited_list.txt
 then
   exit 0
+elif [[ "$FNAME" == "critter"*"h" ]]; then
+  echo \#include \<$FNAME\>
+  exit 0
+elif [[ "$FNAME" == "omp.h" ]]; then
+  echo \#include \<$FNAME\>
+  exit 0
 else
   echo $FULLFNAME >> $SCRIPT_DIR/visited_list.txt
   TMP_FILE="${FNAME}.tmp.concat"


### PR DESCRIPTION
this PR fixes the behaviour of `recursive_expand_includes.sh` for `omp.h` and `critter_*.h`